### PR TITLE
Note that protocols built on SIIT are impacted

### DIFF
--- a/draft-gont-6man-deprecate-atomfrag-generation-01.xml
+++ b/draft-gont-6man-deprecate-atomfrag-generation-01.xml
@@ -437,9 +437,9 @@ is formally replaced with:
       generator at the translator.
 
    Flags:  The More Fragments flag is set to zero.  The Don't Fragment
-      (DF) flag is set as follows: If the packet size is less than or
-      equal to 1260 bytes, it is set to zero; otherwise, it is set to
-      one.
+      (DF) flag is set as follows: If the size of the translated IPv4
+      packet is less than or equal to 1260 bytes, it is set to zero;
+      otherwise, it is set to one.
    ---------------- cut here -------------- cut here ----------------
 ]]></artwork>
 </figure>

--- a/draft-ietf-6man-deprecate-atomfrag-generation-01.xml
+++ b/draft-ietf-6man-deprecate-atomfrag-generation-01.xml
@@ -47,18 +47,20 @@
       </address>
 </author>
 
-<author fullname="Tore Anderson" initials="T.A." surname="Anderson">
-<organization>Redpill Linpro</organization>
-<address>
-<postal>
-<street>Vitaminveien 1A</street>
-<city>NO-0485 Oslo</city>
-<country>NORWAY</country>
-</postal>
-<phone>+47 959 31 212</phone>
-<email>tore@redpill-linpro.com</email>
-</address>
-</author>
+    <author fullname="Tore Anderson" initials="T." surname="Anderson">
+      <organization>Redpill Linpro</organization>
+      <address>
+        <postal>
+          <street>Vitaminveien 1A</street>
+          <code>0485</code>
+          <city>Oslo</city>
+          <country>Norway</country>
+        </postal>
+        <phone>+47 959 31 212</phone>
+        <email>tore@redpill-linpro.com</email>
+        <uri>http://www.redpill-linpro.com</uri>
+      </address>
+    </author>
 
     <date year="2014" />
 

--- a/draft-ietf-6man-deprecate-atomfrag-generation-01.xml
+++ b/draft-ietf-6man-deprecate-atomfrag-generation-01.xml
@@ -131,7 +131,7 @@ The core IPv6 specification requires that when a host receives an ICMPv6 "Packet
 </t>
 
 <t>As noted in <xref target="additional-considerations"/>, <xref
-target="RFC6145">SIIT</xref> is the only technology which currently
+target="RFC6145">SIIT</xref> (including derivative protocols such as <xref target="RFC6146">Stateful NAT64</xref>) is the only technology which currently
 makes use of atomic fragments. Unfortunately, an IPv6 node cannot easily
 limit its exposure to the aforementioned attack vector by only generating IPv6 atomic fragments towards IPv4 destinations behind a stateless translator. This is due to the fact that <xref target="RFC6052">Section 3.3 of
 RFC6052</xref> encourages operators to use a Network-Specific Prefix
@@ -569,7 +569,7 @@ is formally replaced with:
     </section>
 
     <section title="Acknowledgements">
-<t>The authors would like to thank (in alphabetical order) Bob Briscoe, Brian Carpenter, Tatuya Jinmei, Jeroen Massar, and Erik Nordmark, for providing valuable comments on earlier versions of this document.</t>
+<t>The authors would like to thank (in alphabetical order) Alberto Leiva, Bob Briscoe, Brian Carpenter, Tatuya Jinmei, Jeroen Massar, and Erik Nordmark, for providing valuable comments on earlier versions of this document.</t>
 <t>Fernando Gont would like to thank Jan Zorz and Go6 Lab &lt;http://go6lab.si/&gt; for providing access to systems and networks that were employed to produce some of tests that resulted in the publication of this document. Additionally, he would like to thank SixXS &lt;https://www.sixxs.net&gt; for providing IPv6 connectivity.</t>
 
     </section>
@@ -592,6 +592,7 @@ is formally replaced with:
 	<?rfc include="reference.RFC.2992" ?>
 	<?rfc include="reference.RFC.5927" ?>
 	<?rfc include="reference.RFC.6052" ?>
+	<?rfc include="reference.RFC.6146" ?>
 	<?rfc include="reference.RFC.6946" ?>
 	<?rfc include="reference.I-D.ietf-6man-predictable-fragment-id" ?>
 	<?rfc include="reference.I-D.gont-v6ops-ipv6-ehs-in-real-world" ?>


### PR DESCRIPTION
Make it clear that it is not only SIIT that is impacted by this draft,
but that it by extension impacts protocols that build on SIIT, such as
Stateful NAT64 (and probably MAP-T, but that's not spelled out).

Alberto Leiva made the observation that this was not clear - credit him
for doing so.
